### PR TITLE
No addresses found case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - php -l tests
 
   # Run unit tests
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
   # Check for coding standard violations
   - vendor/bin/phpcs --standard=PSR2 --ignore=Wsdl src tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org). See [Keep A Changelog](http://keepachangelog.com) for instructions on how to maintain this file.
 
-## 0.2.0 - 2017-05-18
+## 0.2.0 - 2017-05-29
 
 In case non-existing address is searched, instead of exception, an empty array is returned 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org). See [Keep A Changelog](http://keepachangelog.com) for instructions on how to maintain this file.
 
+## 0.2.0 - 2017-05-18
+
+In case non-existing address is searched, instead of exception, an empty array is returned 
+
 ## 0.1 - 2016-01-26
 
 Initial development release

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PHP Library for Omniva API-s
 
-[![Latest Stable Version on Packagist][ico-version]](link-packagist)
+[![Latest Stable Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE.md)
 [![Build Status][ico-travis]][link-travis]
-[![Total Downloads][ico-downloads]](link-downloads)
+[![Total Downloads][ico-downloads]][link-downloads]
 
 A PHP library for interfacing with [Omniva][link-omniva] (former Estonian Postal Service) web API-s without dealing with SOAP (too much).
 
@@ -158,5 +158,5 @@ The Apache 2.0 License (Apache-2.0). Please see [License File](LICENSE.md) for m
 [ico-downloads]: https://poser.pugx.org/bigbank/omniva/downloads
 
 [link-packagist]: https://packagist.org/packages/bigbank/omniva
-[link-travis]: https://travis-ci.org/bigbank/omniva
+[link-travis]: https://travis-ci.org/bigbank-as/omniva
 [link-downloads]: https://packagist.org/packages/bigbank/omniva

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "my/bigbank/omniva",
+    "name": "bigbank/omniva",
     "type": "library",
     "keywords": [
         "bigbank",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bigbank/omniva",
+    "name": "my/bigbank/omniva",
     "type": "library",
     "keywords": [
         "bigbank",

--- a/src/Services/AddressSearch.php
+++ b/src/Services/AddressSearch.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bigbank\Omniva\Services;
 
+use Bigbank\Omniva\Exceptions\OmnivaException;
 use Bigbank\Omniva\Soap\Wsdl\aadressKomponentKoordsType;
 use Bigbank\Omniva\Soap\Wsdl\SingleAddress2_5_1PortTypeService;
 use Bigbank\Omniva\Soap\Wsdl\SingleAddress2_5_1Request;
@@ -57,8 +58,17 @@ class AddressSearch implements AddressSearchInterface
 
         $this->omnivaRequest->setAadress($partialAddress);
         $response  = $this->omnivaService->SingleAddress2_5_1($this->omnivaRequest);
-        $addresses = $response->getAadressKomponentNimekiriKoords()->getAadressKomponent();
-        return $this->formatResponseAddresses($addresses);
+        $responseContent = $response->getVastus();
+
+        if ($responseContent === 'AADRESS_PUUDUB')
+        {
+
+            return [];
+        } else {
+
+            $addresses = $response->getAadressKomponentNimekiriKoords()->getAadressKomponent();
+            return $this->formatResponseAddresses($addresses);
+        }
     }
 
     /**

--- a/src/Services/AddressSearch.php
+++ b/src/Services/AddressSearch.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bigbank\Omniva\Services;
 
-use Bigbank\Omniva\Exceptions\OmnivaException;
 use Bigbank\Omniva\Soap\Wsdl\aadressKomponentKoordsType;
 use Bigbank\Omniva\Soap\Wsdl\SingleAddress2_5_1PortTypeService;
 use Bigbank\Omniva\Soap\Wsdl\SingleAddress2_5_1Request;

--- a/src/Services/AddressSearch.php
+++ b/src/Services/AddressSearch.php
@@ -59,12 +59,9 @@ class AddressSearch implements AddressSearchInterface
         $response  = $this->omnivaService->SingleAddress2_5_1($this->omnivaRequest);
         $responseContent = $response->getVastus();
 
-        if ($responseContent === 'AADRESS_PUUDUB')
-        {
-
+        if ($responseContent === 'AADRESS_PUUDUB') {
             return [];
         } else {
-
             $addresses = $response->getAadressKomponentNimekiriKoords()->getAadressKomponent();
             return $this->formatResponseAddresses($addresses);
         }

--- a/tests/Services/AddressSearchTest.php
+++ b/tests/Services/AddressSearchTest.php
@@ -79,6 +79,39 @@ class AddressSearchTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::findAddresses no addresses found
+     */
+    public function testFindAddressesReturnsEmptyArray()
+    {
+
+        // Create SOAP request and response DTO-s
+        $request  = new SingleAddress2_5_1Request;
+        $response = new SingleAddress2_5_1ResponseType(
+            new aadressKomponentNimekiriKoordsType([])
+        );
+
+        // Mock the SOAP service class to return the response DTO
+        /** @var SingleAddress2_5_1PortTypeService|\PHPUnit_Framework_MockObject_MockObject $mockSoapService */
+        $mockSoapService = $this->getMockBuilder(SingleAddress2_5_1PortTypeService::class)
+            ->setMethods(['SingleAddress2_5_1'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockSoapService->expects($this->once())
+            ->method('SingleAddress2_5_1')
+            ->with($this->callback(function (SingleAddress2_5_1Request $request) {
+
+                return $request->getAadress() === 'TartuPoleOlemas';
+            }))
+            ->willReturn($response);
+
+        $addressSearch = new AddressSearch($mockSoapService, $request);
+
+        $addresses = $addressSearch->findAddresses('TartuPoleOlemas');
+
+        $this->assertSame([], $addresses);
+    }
+
+    /**
      * @return aadressKomponentKoordsType
      */
     protected function createTestAddress()


### PR DESCRIPTION
In case of no addresses found in Omniva, an empty array is returned instead of general 530 exception.